### PR TITLE
Partition by Day

### DIFF
--- a/src/main/scala/com/appsflyer/spark/bigquery/package.scala
+++ b/src/main/scala/com/appsflyer/spark/bigquery/package.scala
@@ -22,11 +22,11 @@ package object bigquery {
       */
     def setBigQueryProjectId(projectId: String): Unit = {
       hadoopConf.set(BigQueryConfiguration.PROJECT_ID_KEY, projectId)
+    }
 
+    def setGSProjectId(projectId: String): Unit = {
       // Also set project ID for GCS connector
-      if (hadoopConf.get("fs.gs.project.id") == null) {
-        hadoopConf.set("fs.gs.project.id", projectId)
-      }
+      hadoopConf.set("fs.gs.project.id", projectId)
     }
 
     /**

--- a/src/main/scala/com/appsflyer/spark/bigquery/streaming/package.scala
+++ b/src/main/scala/com/appsflyer/spark/bigquery/streaming/package.scala
@@ -23,9 +23,11 @@ package object streaming {
       *                                    [optional projectId]:[datasetId].[tableId]
       * @param batchSize                   number of rows to write to BigQuery at once
       *                                    (default: 500)
+      * @param isPartitionedByDay          Partition table by day
+      *                                    (default: 500)
       */
-    def bigQueryTable(fullyQualifiedOutputTableId: String, batchSize: Int = 500): Unit = {
-      val bigQueryWriter = new BigQueryStreamWriter(fullyQualifiedOutputTableId, batchSize)
+    def bigQueryTable(fullyQualifiedOutputTableId: String, batchSize: Int = 500, isPartitionedByDay: Boolean = false): Unit = {
+      val bigQueryWriter = new BigQueryStreamWriter(fullyQualifiedOutputTableId, batchSize, isPartitionedByDay)
       writer.foreach(bigQueryWriter)
         .start
     }


### PR DESCRIPTION
This PR was inspired by this [issue](https://github.com/spotify/spark-bigquery/issues/13)

At the moment there is no way of partitioning by day via the job configuration, see [here](http://stackoverflow.com/questions/40665794/table-partitioning-scheme-with-load-job-configuration/40793663#40793663). Google engineers are ofcourse working on it

In the meantime us mortals will have to settle for using the client


