### PR TITLE
Partition by day on dataframe

### DIFF
--- a/src/main/scala/com/appsflyer/spark/bigquery/package.scala
+++ b/src/main/scala/com/appsflyer/spark/bigquery/package.scala
@@ -1,6 +1,7 @@
 package com.appsflyer.spark
 
 import com.appsflyer.spark.bigquery.streaming._
+import com.appsflyer.spark.utils.BigQueryPartitionUtils
 import com.google.cloud.hadoop.io.bigquery.{BigQueryConfiguration, BigQueryOutputFormat}
 import com.google.gson.JsonParser
 import org.apache.spark.sql._
@@ -78,12 +79,17 @@ package object bigquery {
       * @param fullyQualifiedOutputTableId output-table id of the form
       *                                    [optional projectId]:[datasetId].[tableId]
       */
-    def saveAsBigQueryTable(fullyQualifiedOutputTableId: String): Unit = {
+    def saveAsBigQueryTable(fullyQualifiedOutputTableId: String, isPartitionedByDay: Boolean = false): Unit = {
       val tableSchema = BigQuerySchema(adaptedDf)
 
       BigQueryConfiguration.configureBigQueryOutput(hadoopConf, fullyQualifiedOutputTableId, tableSchema)
       hadoopConf.set("mapreduce.job.outputformat.class", classOf[BigQueryOutputFormat[_, _]].getName)
+      val bqService = BigQueryServiceFactory.getService
+      val targetTable = BigQueryStrings.parseTableReference(fullyQualifiedOutputTableId)
 
+      if(isPartitionedByDay) {
+        BigQueryPartitionUtils.createBigQueryPartitionedTable(targetTable,bqService)
+      }
       adaptedDf
         .toJSON
         .rdd

--- a/src/main/scala/com/appsflyer/spark/bigquery/package.scala
+++ b/src/main/scala/com/appsflyer/spark/bigquery/package.scala
@@ -64,8 +64,7 @@ package object bigquery {
     * Enhanced version of DataFrame with BigQuery support.
     */
   implicit class BigQueryDataFrame(df: DataFrame) extends Serializable {
-
-    val adaptedDf = BigQueryAdapter(df)
+    val adaptedDf: DataFrame = BigQueryAdapter(df)
 
     @transient
     lazy val hadoopConf = df.sqlContext.sparkContext.hadoopConfiguration

--- a/src/main/scala/com/appsflyer/spark/bigquery/streaming/BigQueryStreamWriter.scala
+++ b/src/main/scala/com/appsflyer/spark/bigquery/streaming/BigQueryStreamWriter.scala
@@ -1,6 +1,7 @@
 package com.appsflyer.spark.bigquery.streaming
 
 import com.appsflyer.spark.bigquery.BigQueryServiceFactory
+import com.appsflyer.spark.utils.BigQueryPartitionUtils
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.services.bigquery.Bigquery
 import com.google.api.services.bigquery.model.{Table, TableDataInsertAllRequest, TableReference, TimePartitioning}
@@ -54,26 +55,8 @@ class BigQueryStreamWriter(fullyQualifiedOutputTableId: String, batchSize: Int,
   }
 
   override def process(value: String): Unit = {
-
     if(isPartitionedByDay) {
-      val datasetId = targetTable.getDatasetId
-      val projectId: String = targetTable.getProjectId
-      val tableName = targetTable.getTableId
-      try {
-        logger.info("Creating Time Partitioned Table")
-        val table = new Table()
-        table.setTableReference(targetTable)
-        val timePartitioning = new TimePartitioning()
-        timePartitioning.setType("DAY")
-        timePartitioning.setExpirationMs(DEFAULT_TABLE_EXPIRATION_MS)
-        table.setTimePartitioning(timePartitioning)
-        val request = bqService.tables().insert(projectId, datasetId, table)
-        val response = request.execute()
-      } catch {
-        case e: GoogleJsonResponseException if e.getStatusCode == 409 =>
-          logger.info(s"$projectId:$datasetId.$tableName already exists")
-        case NonFatal(e) => throw e
-      }
+      BigQueryPartitionUtils.createBigQueryPartitionedTable(targetTable,bqService)
     }
     if (rowIndex < batchSize) {
       rows(rowIndex).setJson(gson.fromJson(value, targetClass)).setInsertId(s"${batchId}_${rowIndex}")

--- a/src/main/scala/com/appsflyer/spark/bigquery/streaming/BigQueryStreamWriter.scala
+++ b/src/main/scala/com/appsflyer/spark/bigquery/streaming/BigQueryStreamWriter.scala
@@ -61,14 +61,14 @@ class BigQueryStreamWriter(fullyQualifiedOutputTableId: String, batchSize: Int,
       val tableName = targetTable.getTableId
       try {
         logger.info("Creating Time Partitioned Table")
-        val table = new Table();
+        val table = new Table()
         table.setTableReference(targetTable)
-        val timePartitioning = new TimePartitioning();
-        timePartitioning.setType("DAY");
-        timePartitioning.setExpirationMs(DEFAULT_TABLE_EXPIRATION_MS);
-        table.setTimePartitioning(timePartitioning);
-        val request = bqService.tables().insert(projectId, datasetId, table);
-        val response = request.execute();
+        val timePartitioning = new TimePartitioning()
+        timePartitioning.setType("DAY")
+        timePartitioning.setExpirationMs(DEFAULT_TABLE_EXPIRATION_MS)
+        table.setTimePartitioning(timePartitioning)
+        val request = bqService.tables().insert(projectId, datasetId, table)
+        val response = request.execute()
       } catch {
         case e: GoogleJsonResponseException if e.getStatusCode == 409 =>
           logger.info(s"$projectId:$datasetId.$tableName already exists")

--- a/src/main/scala/com/appsflyer/spark/utils/BigQueryPartitionUtils.scala
+++ b/src/main/scala/com/appsflyer/spark/utils/BigQueryPartitionUtils.scala
@@ -1,0 +1,38 @@
+package com.appsflyer.spark.utils
+
+import com.appsflyer.spark.bigquery.streaming.BigQueryStreamWriter
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.services.bigquery.Bigquery
+import com.google.api.services.bigquery.model.{Table, TableReference, TimePartitioning}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.util.control.NonFatal
+
+/**
+  * Created by root on 1/9/17.
+  */
+object BigQueryPartitionUtils {
+  private val logger: Logger = LoggerFactory.getLogger(classOf[BigQueryStreamWriter])
+  val DEFAULT_TABLE_EXPIRATION_MS = 259200000L
+
+  def createBigQueryPartitionedTable(targetTable: TableReference, bqService: Bigquery): Any = {
+    val datasetId = targetTable.getDatasetId
+    val projectId: String = targetTable.getProjectId
+    val tableName = targetTable.getTableId
+    try {
+      logger.info("Creating Time Partitioned Table")
+      val table = new Table()
+      table.setTableReference(targetTable)
+      val timePartitioning = new TimePartitioning()
+      timePartitioning.setType("DAY")
+      timePartitioning.setExpirationMs(DEFAULT_TABLE_EXPIRATION_MS)
+      table.setTimePartitioning(timePartitioning)
+      val request = bqService.tables().insert(projectId, datasetId, table)
+      val response = request.execute()
+    } catch {
+      case e: GoogleJsonResponseException if e.getStatusCode == 409 =>
+        logger.info(s"$projectId:$datasetId.$tableName already exists")
+      case NonFatal(e) => throw e
+    }
+  }
+}


### PR DESCRIPTION
FYI we really need to start adding tests, because it seems theres a bug on Google BQ where it cant copy from unpartitioned to partitioned tables. See [here](http://stackoverflow.com/questions/41547293/google-bigquery-spark-incompatible-table-partitioning-specification) and [here](http://stackoverflow.com/questions/38852715/google-bigquery-incompatible-table-partitioning-specification/41547131#41547131)


That said once that bug is resolved this will work

Would you like to merge this in with a warning? or revert the previous merge?

Or can you think of a way to get this working? 